### PR TITLE
feat/Lecture 도메인 기본 구조 구현

### DIFF
--- a/src/main/java/com/example/classpath/domain/lecture/controller/LectureController.java
+++ b/src/main/java/com/example/classpath/domain/lecture/controller/LectureController.java
@@ -1,0 +1,13 @@
+package com.example.classpath.domain.lecture.controller;
+
+import com.example.classpath.domain.lecture.service.LectureService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/lectures")
+@RequiredArgsConstructor
+public class LectureController {
+    private final LectureService lectureService;
+}

--- a/src/main/java/com/example/classpath/domain/lecture/dto/LectureCreateRequest.java
+++ b/src/main/java/com/example/classpath/domain/lecture/dto/LectureCreateRequest.java
@@ -1,0 +1,35 @@
+package com.example.classpath.domain.lecture.dto;
+
+import com.example.classpath.domain.lecture.entity.DayOfWeek;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+
+public class LectureCreateRequest {
+    // TODO 검증 메시지는 추후에 resource 파일로 관리할 예정
+
+    @NotBlank
+    private String name;
+    @NotBlank
+    private String code;
+
+    @Positive
+    @NotNull
+    private Integer maxEnrollment;
+
+    @NotNull
+    private DayOfWeek dayOfWeek;
+
+    @NotNull
+    private LocalTime startTime;
+
+    @NotNull
+    private LocalTime endTime;
+}

--- a/src/main/java/com/example/classpath/domain/lecture/dto/LectureResponse.java
+++ b/src/main/java/com/example/classpath/domain/lecture/dto/LectureResponse.java
@@ -1,0 +1,34 @@
+package com.example.classpath.domain.lecture.dto;
+
+import com.example.classpath.domain.lecture.entity.DayOfWeek;
+import com.example.classpath.domain.lecture.entity.Lecture;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+public class LectureResponse {
+    private Long id;
+    private String name;
+    private String code;
+    private Integer maxEnrollment;
+    private Integer currentEnrollment;
+    private DayOfWeek dayOfWeek;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public LectureResponse(Lecture lecture) {
+        this.id = lecture.getId();
+        this.name = lecture.getName();
+        this.code = lecture.getCode();
+        this.maxEnrollment = lecture.getMaxEnrollment();
+        this.currentEnrollment = lecture.getCurrentEnrollment();
+        this.dayOfWeek = lecture.getDayOfWeek();
+        this.startTime = lecture.getEndTime();
+        this.endTime = lecture.getEndTime();
+        // TODO createdAt, modifiedAt 추가
+    }
+}

--- a/src/main/java/com/example/classpath/domain/lecture/dto/LectureResponse.java
+++ b/src/main/java/com/example/classpath/domain/lecture/dto/LectureResponse.java
@@ -27,7 +27,7 @@ public class LectureResponse {
         this.maxEnrollment = lecture.getMaxEnrollment();
         this.currentEnrollment = lecture.getCurrentEnrollment();
         this.dayOfWeek = lecture.getDayOfWeek();
-        this.startTime = lecture.getEndTime();
+        this.startTime = lecture.getStartTime();
         this.endTime = lecture.getEndTime();
         // TODO createdAt, modifiedAt 추가
     }

--- a/src/main/java/com/example/classpath/domain/lecture/entity/DayOfWeek.java
+++ b/src/main/java/com/example/classpath/domain/lecture/entity/DayOfWeek.java
@@ -1,0 +1,11 @@
+package com.example.classpath.domain.lecture.entity;
+
+public enum DayOfWeek {
+    MON,    // Monday
+    TUE,    // Tuesday
+    WED,    // Wednesday
+    THU,    // Thursday
+    FRI,    // Friday
+    SAT,    // Saturday
+    SUN     // Sunday
+}

--- a/src/main/java/com/example/classpath/domain/lecture/entity/Lecture.java
+++ b/src/main/java/com/example/classpath/domain/lecture/entity/Lecture.java
@@ -37,17 +37,17 @@ public class Lecture { //TODO BaseEntity 상속
     private LocalTime endTime;
 
 
-    private Lecture(String name, String code, Integer maxEnrollment, Integer currentEnrollment, DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
+    private Lecture(String name, String code, Integer maxEnrollment, DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
         this.name = name;
         this.code = code;
         this.maxEnrollment = maxEnrollment;
-        this.currentEnrollment = currentEnrollment;
+        this.currentEnrollment = 0;
         this.dayOfWeek = dayOfWeek;
         this.startTime = startTime;
         this.endTime = endTime;
     }
 
-    public static Lecture of(String name, String code, Integer maxEnrollment, Integer currentEnrollment, DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
-        return new Lecture(name, code, maxEnrollment, currentEnrollment, dayOfWeek, startTime, endTime);
+    public static Lecture of(String name, String code, Integer maxEnrollment, DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
+        return new Lecture(name, code, maxEnrollment, dayOfWeek, startTime, endTime);
     }
 }

--- a/src/main/java/com/example/classpath/domain/lecture/entity/Lecture.java
+++ b/src/main/java/com/example/classpath/domain/lecture/entity/Lecture.java
@@ -1,0 +1,53 @@
+package com.example.classpath.domain.lecture.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Lecture { //TODO BaseEntity 상속
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Column(unique = true)
+    private String code;
+
+    @Column(name = "max_enrollment")
+    private Integer maxEnrollment;
+
+    @Column(name = "current_enrollment")
+    private Integer currentEnrollment;
+
+    @Column(name = "day_of_week")
+    @Enumerated(value = EnumType.STRING)
+    private DayOfWeek dayOfWeek;
+
+    @Column(name = "start_time")
+    private LocalTime startTime;
+
+    @Column(name = "end_time")
+    private LocalTime endTime;
+
+
+    private Lecture(String name, String code, Integer maxEnrollment, Integer currentEnrollment, DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
+        this.name = name;
+        this.code = code;
+        this.maxEnrollment = maxEnrollment;
+        this.currentEnrollment = currentEnrollment;
+        this.dayOfWeek = dayOfWeek;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public static Lecture of(String name, String code, Integer maxEnrollment, Integer currentEnrollment, DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
+        return new Lecture(name, code, maxEnrollment, currentEnrollment, dayOfWeek, startTime, endTime);
+    }
+}

--- a/src/main/java/com/example/classpath/domain/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/example/classpath/domain/lecture/repository/LectureRepository.java
@@ -1,0 +1,7 @@
+package com.example.classpath.domain.lecture.repository;
+
+import com.example.classpath.domain.lecture.entity.Lecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LectureRepository extends JpaRepository<Lecture,Long> {
+}

--- a/src/main/java/com/example/classpath/domain/lecture/service/LectureService.java
+++ b/src/main/java/com/example/classpath/domain/lecture/service/LectureService.java
@@ -1,0 +1,14 @@
+package com.example.classpath.domain.lecture.service;
+
+import com.example.classpath.domain.lecture.repository.LectureRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LectureService {
+    private final LectureRepository lectureRepository;
+
+}


### PR DESCRIPTION
### 작업 내용 요약
- Lecture 도메인 기본 구조 생성  
    - Entity : `Lecture` , `DayofWeek`(enum)
    - Contorller : `LectureController` (빈 파일)
    - Service : `LectureService` (빈 파일)
    - Repository : `LectureRepository` (빈 파일)
   
### 생성한 파일/패키지
domain.lecture.entity.Lecture
domain.lecture.entity.dayOfWeek
domain.lecture.controller.LectureController
domain.lecture.service.LectureService
domain.lecture.repository.LectureRepository
domain.lecture.dto.LectureCreateRequest
domain.lecture.dto.LectureResponse