### PR TITLE
Feat/exception handler 커스텀 예외, Bean Validation 예외 처리 구현

### DIFF
--- a/src/main/java/com/example/classpath/global/common/ErrorBody.java
+++ b/src/main/java/com/example/classpath/global/common/ErrorBody.java
@@ -3,8 +3,13 @@ package com.example.classpath.global.common;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
-@Builder
 public class ErrorBody {
-    private ErrorDetail error;
+    private List<ErrorDetail> errors;
+
+    public ErrorBody(List<ErrorDetail> errors) {
+        this.errors = errors;
+    }
 }

--- a/src/main/java/com/example/classpath/global/exception/BusinessException.java
+++ b/src/main/java/com/example/classpath/global/exception/BusinessException.java
@@ -1,0 +1,19 @@
+package com.example.classpath.global.exception;
+
+import com.example.classpath.global.common.ErrorType;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorType errorType;
+
+    public BusinessException(ErrorType errorType) {
+        super(errorType.getErrorMessage());
+        this.errorType = errorType;
+    }
+
+    public BusinessException(ErrorType errorType, String message) {
+        super(message);
+        this.errorType = errorType;
+    }
+}

--- a/src/main/java/com/example/classpath/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/classpath/global/exception/handler/GlobalExceptionHandler.java
@@ -1,19 +1,45 @@
 package com.example.classpath.global.exception.handler;
 
 import com.example.classpath.global.common.ApiResponse;
+import com.example.classpath.global.common.ErrorBody;
+import com.example.classpath.global.common.ErrorDetail;
 import com.example.classpath.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
+    private final MessageSource messageSource;
+
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
         return ResponseEntity.status(e.getErrorType().getHttpStatus()).body(ApiResponse.error(e.getErrorType()));
+    }
+    
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<ErrorBody>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        List<ErrorDetail> errors = new ArrayList<>();
+        for (FieldError fieldError : e.getBindingResult().getFieldErrors()) {
+            ErrorDetail errorDetail = ErrorDetail.builder()
+                    .field(fieldError.getField())
+                    .message(messageSource.getMessage(Objects.requireNonNull(fieldError), Locale.KOREA))
+                    .build();
+            errors.add(errorDetail);
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.validationError("요청값이 올바르지 않습니다.", new ErrorBody(errors)));
     }
 
 }

--- a/src/main/java/com/example/classpath/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/classpath/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.example.classpath.global.exception.handler;
+
+import com.example.classpath.global.common.ApiResponse;
+import com.example.classpath.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        return ResponseEntity.status(e.getErrorType().getHttpStatus()).body(ApiResponse.error(e.getErrorType()));
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,6 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 # =============================
 jwt.secret=${JWT_SECRET:defaultSecretKey}
 jwt.expiration=${JWT_EXPIRATION:3600000} # milliseconds (1 hour)
+
+# ??? ?? ??
+spring.messages.basename=validation

--- a/src/main/resources/validation.properties
+++ b/src/main/resources/validation.properties
@@ -1,0 +1,18 @@
+#NotBlank={0}은 필수입니다.
+#NotNull={0}은 필수입니다.
+#Size={0}은 {2}~{1}자 사이여야 합니다.
+#------------------------------------------------
+
+NotNull.maxEnrollment=강의 정원은 필수입니다.
+NotNull.dayOfWeek=강의 요일은 필수입니다.
+
+Positive.maxEnrollment=강의 정원은 0명보다 많아야 합니다.
+
+
+
+
+#-------------------------------------------------
+NotBlank.lectureCreateRequest.name=강의 이름은 필수입니다.
+NotBlank.lectureCreateRequest.code=강의 코드는 필수입니다.
+NotNull.lectureCreateRequest.startTime=강의 시작 시간은 필수입니다.
+NotNull.lectureCreateRequest.endTime=강의 종료 시간은 필수입니다.


### PR DESCRIPTION
### 작업 내용 요약
- GlobalExceptionHanlder 생성
- BusinessException 생성
    - BusinessException 전역 예외 처리 구현
- BeanValidation 전역 예외 처리
  - ErrorBody 내부 ErrorDetail 필드 자료형 List로 변환
  - validation.properties 생성
 
### 생성한 파일/패키지
global.exception.GlobalExceptionHandler
global.exception.BusinessException
resources.validation




![image](https://github.com/user-attachments/assets/cf9bfcb2-3dc8-4cf0-815b-6935373d453a)

resources 하위에 validaton.properties에서 검증 메시지를 가져와서 리턴하게 됩니다.
여러분이 작성한 DTO의 검증 default Message가 동작하도록 validation.properties의
#NotBlank={0}은 필수입니다.
#NotNull={0}은 필수입니다.
#Size={0}은 {2}~{1}자 사이여야 합니다.
들은 현재 주석시켰습니다. 따라서 구현 하시던대로 @NotNull(message =...) 로 계속 구현하셔도 됩니다!
궁금한 점은 질문 주세요!