### PR TITLE
feat: 수강 신청 기능 구현

### DIFF
--- a/src/main/java/com/example/classpath/domain/enrollment/dto/request/EnrollmentRequest.java
+++ b/src/main/java/com/example/classpath/domain/enrollment/dto/request/EnrollmentRequest.java
@@ -1,0 +1,19 @@
+package com.example.classpath.domain.enrollment.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class EnrollmentRequest {
+
+    @NotNull(message = "유저 ID는 필수입니다.")
+    private final Long userId;
+
+    @NotNull(message = "강의 ID는 필수입니다.")
+    private final Long lectureId;
+
+    public EnrollmentRequest(Long userId, Long lectureId) {
+        this.userId = userId;
+        this.lectureId = lectureId;
+    }
+}

--- a/src/main/java/com/example/classpath/domain/enrollment/entity/Enrollment.java
+++ b/src/main/java/com/example/classpath/domain/enrollment/entity/Enrollment.java
@@ -1,0 +1,37 @@
+package com.example.classpath.domain.enrollment.entity;
+
+import com.example.classpath.domain.lecture.entity.Lecture;
+import com.example.classpath.domain.user.entity.User;
+import com.example.classpath.global.common.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Enrollment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lecture_id", nullable = false)
+    private Lecture lecture;
+}

--- a/src/main/java/com/example/classpath/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/example/classpath/domain/enrollment/repository/EnrollmentRepository.java
@@ -1,0 +1,11 @@
+package com.example.classpath.domain.enrollment.repository;
+
+import com.example.classpath.domain.enrollment.entity.Enrollment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+
+    boolean existsByUserIdAndLectureId(Long userId, Long lectureId);
+
+    void deleteByUserIdAndLectureId(Long userId, Long lectureId);
+}

--- a/src/main/java/com/example/classpath/domain/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/example/classpath/domain/enrollment/service/EnrollmentService.java
@@ -1,0 +1,46 @@
+package com.example.classpath.domain.enrollment.service;
+
+import com.example.classpath.domain.enrollment.entity.Enrollment;
+import com.example.classpath.domain.enrollment.repository.EnrollmentRepository;
+import com.example.classpath.domain.lecture.entity.Lecture;
+import com.example.classpath.domain.lecture.repository.LectureRepository;
+import com.example.classpath.domain.user.entity.User;
+import com.example.classpath.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class EnrollmentService {
+
+    private final EnrollmentRepository enrollmentRepository;
+    private final UserRepository userRepository;
+    private final LectureRepository lectureRepository;
+
+    @Transactional
+    public void enroll(Long userId, Long lectureId) {
+        if (enrollmentRepository.existsByUserIdAndLectureId(userId, lectureId)) {
+            throw new IllegalArgumentException();
+        }
+
+        User user = userRepository.findById(userId)
+                                  .orElseThrow(() -> {
+                                      // TODO: 커스텀 예외로 교체
+                                      throw new IllegalArgumentException("해당 유저가 존재하지 않습니다.");
+                                  });
+
+        Lecture lecture = lectureRepository.findById(lectureId)
+                                           .orElseThrow(() -> {
+                                               // TODO: 커스텀 예외로 교체
+                                               throw new IllegalArgumentException(
+                                                   "해당 강의가 존재하지 않습니다.");
+                                           });
+
+        Enrollment enrollment = Enrollment.builder()
+                                          .user(user)
+                                          .lecture(lecture)
+                                          .build();
+        enrollmentRepository.save(enrollment);
+    }
+}


### PR DESCRIPTION
### 작업 내용 요약
- Enrollment 엔티티에 User, Lecture 연관관계(@ManyToOne, @JoinColumn) 적용
- 수강 신청 기능(EnrollmentService.enroll) 구현
- EnrollmentController에서 POST /enrollment API 제공
- 중복 신청 및 미존재 유저/강의 예외 처리 부분은 IllegalArgumentException 사용하며, 추후 CustomException으로 리팩토링 예정

### 참고
- 추후 커스텀 예외, 글로벌 예외 처리, 동시성 제어 기능 추가 예정
- Lecture 도메인 생성 후 연관관계 및 기능 확장 필요