### PR TITLE
feat: NoticeController에서 사용자 주입 방식 변경 및 공지사항 전체 페이징 조회 추가

### DIFF
--- a/src/main/java/com/example/classpath/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/classpath/domain/notice/controller/NoticeController.java
@@ -7,10 +7,13 @@ import com.example.classpath.global.common.ApiResponse;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -22,9 +25,21 @@ public class NoticeController {
 
     // 공지 생성
     @PostMapping
-    public ResponseEntity<ApiResponse<NoticeResponseDto>> createNotice(@AuthenticationPrincipal UserDetails userDetails, @Valid @RequestBody NoticeCreateRequestDto requestDto) {
+    public ResponseEntity<ApiResponse<NoticeResponseDto>> createNotice(@Valid @RequestBody NoticeCreateRequestDto requestDto) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        Long userId = (Long) authentication.getPrincipal();
+
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success("공지사항이 생성되었습니다.", noticeService.createNotice(userDetails.getUsername(), requestDto.getTitle(), requestDto.getContents())));
+                .body(ApiResponse.success("공지사항이 생성되었습니다.", noticeService.createNotice(userId, requestDto.getTitle(), requestDto.getContents())));
+    }
+
+    // 공지 전체 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<NoticeResponseDto>>> getNotices(@PageableDefault(size = 20) Pageable pageable) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success("공지사항을 조회하였습니다.", noticeService.getNotices(pageable)));
     }
 
     // 공지 단일 조회

--- a/src/main/java/com/example/classpath/domain/notice/dto/NoticeResponseDto.java
+++ b/src/main/java/com/example/classpath/domain/notice/dto/NoticeResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.classpath.domain.notice.dto;
 
 import com.example.classpath.domain.notice.entity.Notice;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -20,6 +21,7 @@ public class NoticeResponseDto {
 
     private final LocalDateTime modifiedAt;
 
+    @QueryProjection
     public NoticeResponseDto(Notice notice) {
         this.id = notice.getId();
         this.userId = notice.getUser().getId();
@@ -28,5 +30,4 @@ public class NoticeResponseDto {
         this.createdAt = notice.getCreatedAt();
         this.modifiedAt = notice.getModifiedAt();
     }
-
 }

--- a/src/main/java/com/example/classpath/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/example/classpath/domain/notice/repository/NoticeRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface NoticeRepository extends JpaRepository<Notice, Long> {
+public interface NoticeRepository extends JpaRepository<Notice, Long>, NoticeRepositoryCustom {
 }

--- a/src/main/java/com/example/classpath/domain/notice/repository/NoticeRepositoryCustom.java
+++ b/src/main/java/com/example/classpath/domain/notice/repository/NoticeRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.example.classpath.domain.notice.repository;
+
+import com.example.classpath.domain.notice.dto.NoticeResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NoticeRepositoryCustom {
+    Page<NoticeResponseDto> findNotices(Pageable pageable);
+}

--- a/src/main/java/com/example/classpath/domain/notice/repository/NoticeRepositoryCustomImpl.java
+++ b/src/main/java/com/example/classpath/domain/notice/repository/NoticeRepositoryCustomImpl.java
@@ -1,0 +1,39 @@
+package com.example.classpath.domain.notice.repository;
+
+import com.example.classpath.domain.notice.dto.NoticeResponseDto;
+import com.example.classpath.domain.notice.dto.QNoticeResponseDto;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+
+import static com.example.classpath.domain.notice.entity.QNotice.notice;
+
+public class NoticeRepositoryCustomImpl implements NoticeRepositoryCustom{
+    private final EntityManager em;
+    private final JPAQueryFactory queryFactory;
+
+    public NoticeRepositoryCustomImpl(EntityManager em) {
+        this.em = em;
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<NoticeResponseDto> findNotices(Pageable pageable) {
+        List<NoticeResponseDto> content = queryFactory.select(new QNoticeResponseDto(notice))
+                .from(notice)
+                .orderBy(notice.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory.select(notice.count())
+                .from(notice);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+}

--- a/src/main/java/com/example/classpath/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/example/classpath/domain/notice/service/NoticeService.java
@@ -10,6 +10,8 @@ import com.example.classpath.global.exception.ErrorType;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 
@@ -21,9 +23,9 @@ public class NoticeService {
     private final UserRepository userRepository;
 
     // 공지 생성
-    public NoticeResponseDto createNotice(String userNumber, String title, String contents) {
+    public NoticeResponseDto createNotice(Long userId, String title, String contents) {
 
-        User user = userRepository.findByUserNumber(userNumber)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorType.USER_NOT_FOUND));
 
         Notice notice = new Notice(user, title, contents);
@@ -31,6 +33,11 @@ public class NoticeService {
         Notice saved = noticeRepository.save(notice);
 
         return new NoticeResponseDto(saved);
+    }
+
+    // 공지 전체 조회
+    public Page<NoticeResponseDto> getNotices(Pageable pageable) {
+        return noticeRepository.findNotices(pageable);
     }
 
     // 공지 단일 조회


### PR DESCRIPTION
## 작업 내용 요약
- NoticeController에서 SecurityContextHolder을 이용한 사용자 id 주입 방식으로 변경
- 공지사항 전체 페이징 조회 추가 getNotices (공지사항 최신순으로 조회)

## 추가된 내용
- NoticeRepositoryCustom 클래스 추가
- NoticeRepositoryCustomImpl 클래스 추가
- NoticeResponseDto클래스 생성자 부분에 @QueryProjection 추가
- NoticeRepository 클래스가 NoticeRepositoryCustom을 상속